### PR TITLE
fix: patch the consistency of transaction receipts with a different chain-id

### DIFF
--- a/rpc/backend/backend_suite_test.go
+++ b/rpc/backend/backend_suite_test.go
@@ -115,6 +115,32 @@ func (suite *BackendTestSuite) buildEthereumTx() (*evmtypes.MsgEthereumTx, []byt
 	return msgEthereumTx, bz
 }
 
+func (suite *BackendTestSuite) buildEthereumTxWithChainId(chainId *big.Int) (*evmtypes.MsgEthereumTx, []byte) {
+	msgEthereumTx := evmtypes.NewTx(
+		chainId,
+		uint64(0),
+		&common.Address{},
+		big.NewInt(0),
+		100000,
+		big.NewInt(1),
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	// A valid msg should have empty `From`
+	msgEthereumTx.From = ""
+
+	txBuilder := suite.backend.clientCtx.TxConfig.NewTxBuilder()
+	err := txBuilder.SetMsgs(msgEthereumTx)
+	suite.Require().NoError(err)
+
+	bz, err := suite.backend.clientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
+	suite.Require().NoError(err)
+	return msgEthereumTx, bz
+}
+
 // buildFormattedBlock returns a formatted block for testing
 func (suite *BackendTestSuite) buildFormattedBlock(
 	blockRes *tmrpctypes.ResultBlockResults,

--- a/rpc/backend/tx_info.go
+++ b/rpc/backend/tx_info.go
@@ -194,7 +194,16 @@ func (b *Backend) GetTransactionReceipt(hash common.Hash) (map[string]interface{
 		return nil, err
 	}
 
-	from, err := ethMsg.GetSender(chainID.ToInt())
+	// NOTE
+	// This patch applies only to the period when the chain-id was set to 9000 between the v8 and v8.1.1 versions of Canto.
+	// It is intended to ensure that reverted transaction receipt returns the same results instead of 'invalid chain id' error.
+	// The upgrade height for v8 is 10848200, and for v8.1.1, it is  10849447.
+	var from common.Address
+	if res.Height >= 10848200 && res.Height < 10849447 {
+		from, err = ethMsg.GetSender(big.NewInt(9000)) // 9000 is the default chain-id that was applied during that period.
+	} else {
+		from, err = ethMsg.GetSender(chainID.ToInt())
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -10,11 +10,14 @@ import (
 	tmrpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/evmos/ethermint/indexer"
 	"github.com/evmos/ethermint/rpc/backend/mocks"
 	rpctypes "github.com/evmos/ethermint/rpc/types"
+	"github.com/evmos/ethermint/tests"
 	ethermint "github.com/evmos/ethermint/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"google.golang.org/grpc/metadata"
@@ -601,6 +604,179 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 			} else {
 				suite.Require().NotEqual(txReceipt, tc.expTxReceipt)
 			}
+		})
+	}
+}
+
+func (suite *BackendTestSuite) TestCheckChainIdWithTransactionReceipt() {
+
+	patchedHeight := int64(10848200)
+	notPatchedHeight := int64(10848100)
+
+	// TX using chain id 9000
+	from, pk := tests.NewAddrKey()
+	msgEthereumTx, _ := suite.buildEthereumTxWithChainId(big.NewInt(9000))
+	txHash := msgEthereumTx.AsTransaction().Hash()
+
+	signer := tests.NewSigner(pk)
+	ethSigner := ethtypes.NewLondonSigner(big.NewInt(9000))
+	msgEthereumTx.From = from.String()
+	err := msgEthereumTx.Sign(ethSigner, signer)
+	suite.NoError(err)
+
+	tx, err := msgEthereumTx.BuildTx(suite.backend.clientCtx.TxConfig.NewTxBuilder(), "aphoton")
+	suite.NoError(err)
+	txEncoder := suite.backend.clientCtx.TxConfig.TxEncoder()
+	txBz, err := txEncoder(tx)
+	suite.NoError(err)
+
+	testCases := []struct {
+		name            string
+		registerMock    func()
+		tx              *evmtypes.MsgEthereumTx
+		block           *types.Block
+		blockResult     *abci.ResponseFinalizeBlock
+		expTxReceipt    map[string]interface{}
+		expKeyMatchPass bool
+		expApiPass      bool
+	}{
+		{
+			"success- Receipts with a different chain ID within a patched height",
+			func() {
+
+				ctx := server.NewDefaultContext()
+
+				// overwrite client conext
+				suite.backend.clientCtx.WithChainID("canto_7700-1").WithHeight(patchedHeight)
+
+				idxer := indexer.NewKVIndexer(dbm.NewMemDB(), ctx.Logger, suite.backend.clientCtx)
+				suite.backend = NewBackend(ctx, ctx.Logger, suite.backend.clientCtx, true, idxer)
+				suite.backend.queryClient.QueryClient = mocks.NewEVMQueryClient(suite.T())
+				suite.backend.clientCtx.Client = mocks.NewClient(suite.T())
+				suite.backend.queryClient.FeeMarket = mocks.NewFeeMarketQueryClient(suite.T())
+				suite.backend.ctx = rpctypes.ContextWithHeight(patchedHeight)
+
+				var header metadata.MD
+				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+				client := suite.backend.clientCtx.Client.(*mocks.Client)
+				RegisterParams(queryClient, &header, patchedHeight)
+				RegisterParamsWithoutHeader(queryClient, patchedHeight)
+				RegisterBlock(client, patchedHeight, txBz)
+				RegisterBlockResults(client, patchedHeight)
+			},
+			msgEthereumTx,
+			&types.Block{Header: types.Header{Height: patchedHeight}, Data: types.Data{Txs: []types.Tx{txBz}}},
+			&abci.ResponseFinalizeBlock{
+				TxResults: []*abci.ExecTxResult{
+					{
+						Code: 0,
+						Events: []abci.Event{
+							{Type: evmtypes.EventTypeEthereumTx, Attributes: []abci.EventAttribute{
+								{Key: "ethereumTxHash", Value: txHash.Hex()},
+								{Key: "txIndex", Value: "0"},
+								{Key: "amount", Value: "1000"},
+								{Key: "txGasUsed", Value: "21000"},
+								{Key: "txHash", Value: ""},
+								{Key: "recipient", Value: "0x775b87ef5D82ca211811C1a02CE0fE0CA3a455d7"},
+								{Key: "status", Value: "0x0"},
+							}},
+						},
+					},
+				},
+			},
+			map[string]interface{}(nil),
+			true,
+			true,
+		},
+		{
+			"false- Receipts with a different chain ID not in the patched height. expected to return an invalid chain ID",
+			func() {
+
+				ctx := server.NewDefaultContext()
+
+				// overwrite client conext
+				suite.backend.clientCtx = suite.backend.clientCtx.WithChainID("canto_7700-1").WithHeight(notPatchedHeight)
+
+				idxer := indexer.NewKVIndexer(dbm.NewMemDB(), ctx.Logger, suite.backend.clientCtx)
+				suite.backend = NewBackend(ctx, ctx.Logger, suite.backend.clientCtx, true, idxer)
+				suite.backend.queryClient.QueryClient = mocks.NewEVMQueryClient(suite.T())
+				suite.backend.clientCtx.Client = mocks.NewClient(suite.T())
+				suite.backend.queryClient.FeeMarket = mocks.NewFeeMarketQueryClient(suite.T())
+				suite.backend.ctx = rpctypes.ContextWithHeight(notPatchedHeight)
+
+				var header metadata.MD
+				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
+				client := suite.backend.clientCtx.Client.(*mocks.Client)
+				RegisterParams(queryClient, &header, notPatchedHeight)
+				RegisterParamsWithoutHeader(queryClient, notPatchedHeight)
+				RegisterBlock(client, notPatchedHeight, txBz)
+				RegisterBlockResults(client, notPatchedHeight)
+			},
+			msgEthereumTx,
+			&types.Block{Header: types.Header{Height: notPatchedHeight}, Data: types.Data{Txs: []types.Tx{txBz}}},
+			&abci.ResponseFinalizeBlock{
+				TxResults: []*abci.ExecTxResult{
+					{
+						Code: 0,
+						Events: []abci.Event{
+							{Type: evmtypes.EventTypeEthereumTx, Attributes: []abci.EventAttribute{
+								{Key: "ethereumTxHash", Value: txHash.Hex()},
+								{Key: "txIndex", Value: "0"},
+								{Key: "amount", Value: "1000"},
+								{Key: "txGasUsed", Value: "21000"},
+								{Key: "txHash", Value: ""},
+								{Key: "recipient", Value: "0x775b87ef5D82ca211811C1a02CE0fE0CA3a455d7"},
+								{Key: "status", Value: "0x0"},
+							}},
+						},
+					},
+				},
+			},
+			map[string]interface{}(nil),
+			false,
+			false, // invalid chain id error
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // reset
+			tc.registerMock()
+
+			db := dbm.NewMemDB()
+			suite.backend.indexer = indexer.NewKVIndexer(db, log.NewNopLogger(), suite.backend.clientCtx)
+			err := suite.backend.indexer.IndexBlock(tc.block, tc.blockResult)
+			suite.Require().NoError(err)
+
+			txReceipt, err := suite.backend.GetTransactionReceipt(common.HexToHash(tc.tx.Hash))
+			if tc.expApiPass {
+				suite.Require().NoError(err)
+
+				if tc.expKeyMatchPass {
+
+					// check all expected receipt keys are exist.
+					for k, _ := range tc.expTxReceipt {
+						_, keyExist := txReceipt[k]
+						suite.Require().True(keyExist)
+					}
+
+				} else {
+
+					anyKeyNotExist := false
+					// check the receipt keys are exist.
+					for k, _ := range tc.expTxReceipt {
+						_, keyExist := txReceipt[k]
+						if !keyExist {
+							anyKeyNotExist = true
+						}
+
+					}
+					suite.Require().True(anyKeyNotExist)
+				}
+			} else {
+				suite.Require().Error(err)
+			}
+
 		})
 	}
 }

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -631,14 +631,13 @@ func (suite *BackendTestSuite) TestCheckChainIdWithTransactionReceipt() {
 	suite.NoError(err)
 
 	testCases := []struct {
-		name            string
-		registerMock    func()
-		tx              *evmtypes.MsgEthereumTx
-		block           *types.Block
-		blockResult     *abci.ResponseFinalizeBlock
-		expTxReceipt    map[string]interface{}
-		expKeyMatchPass bool
-		expApiPass      bool
+		name         string
+		registerMock func()
+		tx           *evmtypes.MsgEthereumTx
+		block        *types.Block
+		blockResult  *abci.ResponseFinalizeBlock
+		expTxReceipt map[string]interface{}
+		expPass      bool
 	}{
 		{
 			"success- Receipts with a different chain ID within a patched height",
@@ -686,7 +685,6 @@ func (suite *BackendTestSuite) TestCheckChainIdWithTransactionReceipt() {
 			},
 			map[string]interface{}(nil),
 			true,
-			true,
 		},
 		{
 			"false- Receipts with a different chain ID not in the patched height. expected to return an invalid chain ID",
@@ -733,7 +731,6 @@ func (suite *BackendTestSuite) TestCheckChainIdWithTransactionReceipt() {
 				},
 			},
 			map[string]interface{}(nil),
-			false,
 			false, // invalid chain id error
 		},
 	}
@@ -749,30 +746,15 @@ func (suite *BackendTestSuite) TestCheckChainIdWithTransactionReceipt() {
 			suite.Require().NoError(err)
 
 			txReceipt, err := suite.backend.GetTransactionReceipt(common.HexToHash(tc.tx.Hash))
-			if tc.expApiPass {
+			if tc.expPass {
 				suite.Require().NoError(err)
 
-				if tc.expKeyMatchPass {
-
-					// check all expected receipt keys are exist.
-					for k, _ := range tc.expTxReceipt {
-						_, keyExist := txReceipt[k]
-						suite.Require().True(keyExist)
-					}
-
-				} else {
-
-					anyKeyNotExist := false
-					// check the receipt keys are exist.
-					for k, _ := range tc.expTxReceipt {
-						_, keyExist := txReceipt[k]
-						if !keyExist {
-							anyKeyNotExist = true
-						}
-
-					}
-					suite.Require().True(anyKeyNotExist)
+				// if test passes, all expected receipt keys should be exist.
+				for k, _ := range tc.expTxReceipt {
+					_, keyExist := txReceipt[k]
+					suite.Require().True(keyExist)
 				}
+
 			} else {
 				suite.Require().Error(err)
 			}


### PR DESCRIPTION
## Description

There was a specific block height that used the Evmos default chain ID (9000). 
This occurred from v8 to v8.1.1 (block heights from 10848200 to 10849447).

Due to this issue, third-party services encountered an 'invalid chain-id' error when attempting to verify transaction results.
This patch addresses the problem by ensuring that the transaction receipt returns the same results as before.

## How to verify
1. Get the all EVM txs hashes using [this script](https://github.com/jasonsong0/check_receipt/blob/master/ext_hash.sh)
```bash
#!/bin/bash

# Base URL
base_url="http://127.0.0.1:26657/block_results?height="

# height  range
start_height=10848200
end_height=10849447

# extract and save all ethereumTxHash to temp file
temp_file=$(mktemp)

# loop each height
for height in $(seq $start_height $end_height)
do
    # parse json and extract hash
    curl -s "${base_url}${height}" | \
    jq -r '.result.txs_results[]?.events[]? | select(.type=="ethereum_tx") | .attributes[] | select(.key=="ethereumTxHash") | .value' >> "$temp_file"
done

# remove duplicated ethereumTxHash
sort "$temp_file" | uniq

# del tmp
rm "$temp_file"
```
2. Check the results of `eth_getTransactionReceipt`. You can use [this script](https://github.com/jasonsong0/check_receipt/blob/master/check_receipt.sh), which already contains EVM hashes from v8 to v8.1.1
```bash
#!/bin/bash

#hash array to check
hashes=(
    "0x17a1cacf3e10d3021157b3b1bb37c20ff5346c198c26b2706b140e15844f8b2c"
    "0x27b110b65da60ba48cbacdbbd603d3c7431e95f76b45ed04825655cff7b987b9"
    "0x287208b0e0ecce2dd2b2ead580cb35906d47568c43d06af415a926c2bdb059fc"
    "0x32a4e3869519be5072136329e135f88cf74168e519866ebea57cc433a40e075c"
    "0x3a2f786c413b25ee3dd0a0b4ce381bf34070057b45d42ec352b74d83a9485214"
    "0x444fbbc3b512ba8a88fb0123a561bf6b705687961842e8b0f36c89e6fd341dd4"
    "0x507c4b2ccbd7a039b87ad1f2c15e4c2f37877afdbd62c8c4335a0a8300d0096d"
    "0x552026b9a81ffe9c3d77d397380732646ad68f1887fcd06b3748ad63ad5c085c"
    "0x634d27ce283d0c048aae0ff51697dd794a3e7330beface61c001f5eb593e1840"
    "0x637d0c673093e8f112eeb57cae831d1355f1341a786c1fd7496c7921fabe2493"
    "0x6be81a6e5fe84f4c78cc51cbcf53862c58f69c633ffcef9ac872786b3a9362bf"
    "0x758c45ec800c05c509204db58e5463b0336750db16056f765001e55a6b1dafb6"
    "0x7af8e965fd437b29a4cdc45ca6bcd83ad5ce5cb631d9515c085529986174af64"
    "0x81e26f5674d3221372648fef0f65ff2d3b1bb9055ffa113e9e14882e7c937fc1"
    "0x83ba7322f5b446b29d9cb3de15a7fe3a0af094d29df8dcc99738ee84d8b778fd"
    "0x875d7cb7668b6ff9d022b809db54f512736190dca58b47a377bea07183d66ff0"
    "0x955fa0f3f4d2b4b32f13d6aabe212e646bcfef158c9a2fff8b4c6086b15474f2"
    "0xad1ba0a2fbf5db4280c72b16ddb1f7eff44881235b7a510fc7ad7f38da12dd49"
    "0xb53f9324f75a8a8867bf1b2a6a7d615418766e609bc3f6f2fc1b25ac4699f6ff"
    "0xbb464dddb0acbb0918d129a7af62b8eec6d55c32bd63e943acc0138668a2acd9"
    "0xbe28ece4dc02ee6f5d2af9a5599746c168896b8161d4f1783c2e49d83ec28d1b"
    "0xcb06d3696ca4811a8fea64c0fda8b2b24280ddeefcd97595fdf4c4af0b172b3c"
    "0xcfd708dc2d7ffd6f7208195fbbe5a1eed0cfb76c4596ed161034acda38d66b0f"
    "0xd15e20cb7271e73725a67cc65fdb9c52367658030dd582b855d3887024d6cb2d"
    "0xd50d17d437012e822b6c122ce0f9fb6601ce0fe8a8a805a644ff32a62dcdc44e"
    "0xea7d2418908a1dff167c40140002d942dff4e5f0e70f0649bdbed5523c85cc7d"
    "0xfb273bd0bbab8456fbc05127cda5ffbee95cb3c2a158e20bb46e63110a47ad97"
)

# curl request receipt
for hash in "${hashes[@]}"
do
    echo "Requesting transaction receipt for hash: $hash"
    
    # curl 
    curl -X POST http://127.0.0.1:8545 \
    -H "Content-Type: application/json" \
    --data "{
      \"jsonrpc\":\"2.0\",
      \"method\":\"eth_getTransactionReceipt\",
      \"params\":[\"$hash\"],
      \"id\":1
    }"
    
    echo -e "\n"
done
```

______

For contributor use:

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
