### PR TITLE
fix: precompile revert for abci1.0

### DIFF
--- a/x/evm/statedb/journal.go
+++ b/x/evm/statedb/journal.go
@@ -249,7 +249,11 @@ func (ch accessListAddSlotChange) dirtied() *common.Address {
 }
 
 func (ch precompileChange) revert(s *StateDB) {
-	s.RevertWithMultiStoreSnapshot(ch.ms)
+	s.cacheCtx = s.cacheCtx.WithMultiStore(ch.ms)
+	s.writeCache = func() {
+		s.cacheCtx.EventManager().EmitEvents(ch.es)
+		ch.ms.CacheMultiStore().Write()
+	}
 }
 
 func (ch precompileChange) dirtied() *common.Address {


### PR DESCRIPTION

## Description

fix revert error for abci1.0.
 - write cache multi store when revert
 - cherry pick https://github.com/b-harvest/ethermint/commit/d40c19c080b711e1ae55669dea29ce8267bd4972. 

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
